### PR TITLE
Core/Quests: Fix transmog illusions so no relog is required

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -435,6 +435,7 @@ namespace
     ToyItemIdsContainer _toys;
     std::unordered_map<uint32, std::vector<TransmogSetEntry const*>> _transmogSetsByItemModifiedAppearance;
     std::unordered_map<uint32, std::vector<TransmogSetItemEntry const*>> _transmogSetItemsByTransmogSet;
+    std::unordered_set<uint32> _transmogUnlockQuests;
     WMOAreaTableLookupContainer _wmoAreaTableLookup;
     WorldMapAreaByAreaIDContainer _worldMapAreaByAreaID;
 }
@@ -1185,6 +1186,13 @@ uint32 DB2Manager::LoadStores(std::string const& dataPath, LocaleConstant defaul
 
     for (SpellClassOptionsEntry const* classOption : sSpellClassOptionsStore)
         _spellFamilyNames.insert(classOption->SpellClassSet);
+
+    for (SpellItemEnchantmentEntry const* entry : sSpellItemEnchantmentStore)
+        if (entry->TransmogUnlockConditionID > 0)
+            if (auto const* condition = sPlayerConditionStore.LookupEntry(entry->TransmogUnlockConditionID))
+                for (int i=0; i<4; i++)
+                    if (condition->PrevQuestID[i] > 0)
+                        _transmogUnlockQuests.emplace(condition->PrevQuestID[i]);
 
     for (SpellProcsPerMinuteModEntry const* ppmMod : sSpellProcsPerMinuteModStore)
         _spellProcsPerMinuteMods[ppmMod->SpellProcsPerMinuteID].push_back(ppmMod);
@@ -2402,6 +2410,11 @@ void DB2Manager::DeterminaAlternateMapPosition(uint32 mapId, float x, float y, f
 
     newPos->X = x + transformation->RegionOffset.X;
     newPos->Y = y + transformation->RegionOffset.Y;
+}
+
+bool DB2Manager::IsTransmogUnlockQuest(uint32 questId)
+{
+    return _transmogUnlockQuests.find(questId) != _transmogUnlockQuests.end();
 }
 
 bool ChrClassesXPowerTypesEntryComparator::Compare(ChrClassesXPowerTypesEntry const* left, ChrClassesXPowerTypesEntry const* right)

--- a/src/server/game/DataStores/DB2Stores.h
+++ b/src/server/game/DataStores/DB2Stores.h
@@ -381,6 +381,7 @@ public:
     void Zone2MapCoordinates(uint32 areaId, float& x, float& y) const;
     void Map2ZoneCoordinates(uint32 areaId, float& x, float& y) const;
     static void DeterminaAlternateMapPosition(uint32 mapId, float x, float y, float z, uint32* newMapId = nullptr, DBCPosition2D* newPos = nullptr);
+    bool IsTransmogUnlockQuest(uint32 questId);
 
 private:
     friend class DB2HotfixGeneratorBase;

--- a/src/server/game/DataStores/DB2Structure.h
+++ b/src/server/game/DataStores/DB2Structure.h
@@ -2982,7 +2982,7 @@ struct SpellItemEnchantmentEntry
     uint8 MaxLevel;
     int8 ScalingClass;
     int8 ScalingClassRestricted;
-    uint32 TransmogUseConditionID;
+    uint32 TransmogUnlockConditionID;
 
     EnumFlag<SpellItemEnchantmentFlags> GetFlags() const { return static_cast<SpellItemEnchantmentFlags>(Flags); }
 };

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1966,7 +1966,7 @@ void WorldSession::HandleEquipmentSetSave(WorldPackets::EquipmentSet::SaveEquipm
             if (!illusion->ItemVisual || !illusion->GetFlags().HasFlag(SpellItemEnchantmentFlags::AllowTransmog))
                 return false;
 
-            if (PlayerConditionEntry const* condition = sPlayerConditionStore.LookupEntry(illusion->TransmogUseConditionID))
+            if (PlayerConditionEntry const* condition = sPlayerConditionStore.LookupEntry(illusion->TransmogUnlockConditionID))
                 if (!sConditionMgr->IsPlayerMeetingCondition(_player, condition))
                     return false;
 

--- a/src/server/game/Handlers/TransmogrificationHandler.cpp
+++ b/src/server/game/Handlers/TransmogrificationHandler.cpp
@@ -129,7 +129,7 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Transmogrification::Tra
                 return;
             }
 
-            if (PlayerConditionEntry const* condition = sPlayerConditionStore.LookupEntry(illusion->TransmogUseConditionID))
+            if (PlayerConditionEntry const* condition = sPlayerConditionStore.LookupEntry(illusion->TransmogUnlockConditionID))
             {
                 if (!sConditionMgr->IsPlayerMeetingCondition(player, condition))
                 {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3653,7 +3653,21 @@ void Spell::EffectQuestComplete()
         if (logSlot < MAX_QUEST_LOG_SIZE)
             player->AreaExploredOrEventHappens(questId);
         else if (quest->HasFlag(QUEST_FLAGS_TRACKING))  // Check if the quest is used as a serverside flag.
-            player->SetRewardedQuest(questId);          // If so, set status to rewarded without broadcasting it to client.
+        {
+            // transmog unlock quests should be immediately sent to client
+            if (sDB2Manager.IsTransmogUnlockQuest(questId))
+            {
+                if (player->GetQuestStatus(questId) == QuestStatus::QUEST_STATUS_NONE)
+                    player->SetQuestStatus(questId, QuestStatus::QUEST_STATUS_INCOMPLETE);
+
+                player->AreaExploredOrEventHappens(questId);
+            }
+            else
+            {
+                // Otherwise, set status to rewarded without broadcasting it to client.
+                player->SetRewardedQuest(questId);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Send quest completion for transmog illusion "tracking" (unlock) quests

**Issues addressed:**

This fixes the issue where transmog illusions are unavailable until logging out and back in with a character.

**Tests performed:**

Tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

None.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
